### PR TITLE
Add plotting functions for miniscope data

### DIFF
--- a/element_miniscope/miniscope_no_curation.py
+++ b/element_miniscope/miniscope_no_curation.py
@@ -741,7 +741,7 @@ class Processing(dj.Computed):
                 }
                 for f in output_dir.rglob("*")
                 if f.is_file()
-            ]
+            ], ignore_extra_fields=True,
         )
 
 

--- a/element_miniscope/miniscope_no_curation.py
+++ b/element_miniscope/miniscope_no_curation.py
@@ -532,7 +532,7 @@ class ProcessingTask(dj.Manual):
     -> RecordingInfo
     -> ProcessingParamSet
     ---
-    processing_output_dir : varchar(255)    # relative to the root data directory
+    processing_output_dir='': varchar(255)    # relative to the root data directory
     task_mode='load'      : enum('load', 'trigger') # 'load': load existing results
                                                     # 'trigger': trigger procedure
     """

--- a/element_miniscope/plotting/cell_plot.py
+++ b/element_miniscope/plotting/cell_plot.py
@@ -1,208 +1,104 @@
-from typing import Tuple
-
-import numpy as np
+import datajoint as dj
 import plotly.graph_objects as go
-from matplotlib import colors
+import numpy as np
 
 
-def mask_overlayed_image(
-    image, mask_xpix, mask_ypix, cell_mask_ids, low_q=0, high_q=0.99
-):
-    """Overlay transparent cell masks on average image."""
+def plot_cell_overlayed_image(
+    miniscope_module, segmentation_key, fig_height=600, fig_width=600
+) -> go.Figure:
 
-    q_min, q_max = np.quantile(image, [low_q, high_q])
-    image = np.clip(image, q_min, q_max)
-    image = (image - q_min) / (q_max - q_min)
-
-    SATURATION = 0.7
-    image = image[:, :, None] * np.array([0, 0, 1])
-    maskid_image = np.full(image.shape[:2], -1)
-    for xpix, ypix, roi_id in zip(mask_xpix, mask_ypix, cell_mask_ids):
-        image[ypix, xpix, :2] = [np.random.rand(), SATURATION]
-        maskid_image[ypix, xpix] = roi_id
-    image = (colors.hsv_to_rgb(image) * 255).astype(int)
-    return image, maskid_image
-
-
-def get_tracelayout(key, width=600, height=600) -> dict:
-    """Returns a dictionary of layout settings for the trace figures."""
-    text = f"Trace for Cell {key['mask']}" if isinstance(key, dict) else "Trace"
-
-    return dict(
-        margin=dict(l=0, r=0, b=0, t=65, pad=0),
-        width=width,
-        height=height,
-        transition={"duration": 0},
-        title={
-            "text": text,
-            "xanchor": "center",
-            "yanchor": "top",
-            "y": 0.97,
-            "x": 0.5,
-        },
-        xaxis={
-            "title": "Time (sec)",
-            "visible": True,
-            "showticklabels": True,
-            "showgrid": True,
-        },
-        yaxis={
-            "title": "Fluorescence (a.u.)",
-            "visible": True,
-            "showticklabels": True,
-            "showgrid": True,
-            "anchor": "free",
-            "overlaying": "y",
-            "side": "left",
-            "position": 0,
-        },
-        yaxis2={
-            "title": "Calcium Event (a.u.)",
-            "visible": True,
-            "showticklabels": True,
-            "showgrid": True,
-            "anchor": "free",
-            "overlaying": "y",
-            "side": "right",
-            "position": 1,
-        },
-        shapes=[
-            go.layout.Shape(
-                type="rect",
-                xref="paper",
-                yref="paper",
-                x0=0,
-                y0=0,
-                x1=1.0,
-                y1=1.0,
-                line={"width": 1, "color": "black"},
-            )
-        ],
-        legend={
-            "traceorder": "normal",
-            "yanchor": "top",
-            "y": 0.99,
-            "xanchor": "right",
-            "x": 0.99,
-        },
-        plot_bgcolor="rgba(0,0,0,0.05)",
-        modebar_remove=[
-            "zoom",
-            "resetScale",
-            "pan",
-            "select",
-            "zoomIn",
-            "zoomOut",
-            "autoScale2d",
-        ],
+    average_image, max_projection_image, mask_ids, mask_xpix, mask_ypix = figure_data(
+        miniscope_module, segmentation_key
     )
 
+    fig = go.Figure()
 
-def figure_data(miniscope_module, segmentation_key) -> Tuple[np.array, np.array]:
-    """Prepare the images for a given segmentation_key.
-
-    Args:
-        miniscope_module (dj.Table): miniscope_module table.
-        segmentation_key (dict): A primary key from Segmentation table.
-
-    Returns:
-        background_with_cells (np.array): Average image with transparently overlayed
-            cells.
-        cells_maskid_image (np.array): Mask ID image.
-    """
-
-    image = (miniscope_module.MotionCorrection.Summary & segmentation_key).fetch1(
-        "average_image"
-    )
-
-    cell_mask_ids, mask_xpix, mask_ypix = (
-        miniscope_module.Segmentation.Mask * miniscope_module.MaskClassification.MaskType
-        & segmentation_key
-    ).fetch("mask", "mask_xpix", "mask_ypix")
-
-    background_with_cells, cells_maskid_image = mask_overlayed_image(
-        image, mask_xpix, mask_ypix, cell_mask_ids, low_q=0, high_q=0.99
-    )
-
-    return background_with_cells, cells_maskid_image
-
-
-def plot_cell_overlayed_image(miniscope_module, segmentation_key) -> go.Figure:
-    """_summary_
-
-    Args:
-        miniscope_module (dj.Table): miniscope_module table.
-        segmentation_key (dict): A primary key from Segmentation table.
-
-    Returns:
-        image_fig (plotly.Fig): Plotly figure object of the average image with
-            transparently overlayed cells.
-    """
-
-    background_with_cells, cells_maskid_image = figure_data(miniscope_module, segmentation_key)
-
-    image_fig = go.Figure(
-        go.Image(
-            z=background_with_cells,
-            hovertemplate="x: %{x} <br>y: %{y} <br>mask_id: %{customdata}",
-            customdata=cells_maskid_image,
+    # Add heatmaps for the average and max projection images
+    fig.add_trace(
+        go.Heatmap(
+            z=average_image,
+            colorscale=[[0, "black"], [1, "white"]],
+            showscale=False,
+            visible=True,  # Initially visible
         )
     )
-    image_fig.update_layout(
-        title="Average Image with Cells",
-        xaxis={
-            "title": "X (px)",
-            "visible": True,
-            "showticklabels": True,
-            "showgrid": False,
-        },
-        yaxis={
-            "title": "Y (px)",
-            "visible": True,
-            "showticklabels": True,
-            "showgrid": False,
-        },
-        paper_bgcolor="rgba(0,0,0,0)",
-        plot_bgcolor="rgba(0,0,0,0)",
+
+    fig.add_trace(
+        go.Heatmap(
+            z=max_projection_image,
+            colorscale=[[0, "black"], [1, "white"]],
+            showscale=False,
+            visible=False,  # Initially hidden
+        )
     )
 
-    return image_fig
+    roi_colors = [
+        f"rgb({np.random.randint(0, 256)}, {np.random.randint(0, 256)}, {np.random.randint(0, 256)})"
+        for _ in range(mask_ids.size)
+    ]
 
-
-def plot_cell_traces(miniscope_module, cell_key) -> go.Figure:
-    """Prepare plotly trace figure.
-
-    Args:
-        miniscope_module (dj.Table): miniscope_module table.
-        cell_key (dict): A primary key from miniscope_module.Activity.Trace table.
-
-    Returns:
-        trace_fig: Plotly figure object of the traces.
-    """
-    activity_trace = (
-        miniscope_module.Activity.Trace & "extraction_method LIKE '%deconvolution'" & cell_key
-    ).fetch1("activity_trace")
-    fluorescence, fps = (miniscope_module.RecordingInfo * miniscope_module.Fluorescence.Trace & cell_key).fetch1(
-        "fluorescence", "fps"
-    )
-
-    trace_fig = go.Figure(
-        [
+    # Add scatter traces for ROI contours
+    for xpix, ypix, color, roi_id in zip(mask_xpix, mask_ypix, roi_colors, mask_ids):
+        fig.add_trace(
             go.Scatter(
-                x=np.arange(len(fluorescence)) / fps,
-                y=fluorescence,
-                name="Fluorescence",
-                yaxis="y1",
-            ),
-            go.Scatter(
-                x=np.arange(len(activity_trace)) / fps,
-                y=activity_trace,
-                name="Calcium Event",
-                yaxis="y2",
-            ),
-        ]
+                x=xpix,
+                y=ypix,
+                mode="lines",
+                line=dict(color=color, width=2),
+                hoverinfo="text",
+                text=[f"ROI {roi_id}"] * len(xpix),  # Display ROI ID on hover
+                showlegend=False,  # Hide legend for ROI contours
+                opacity=0.7,  # Adjust line transparency
+            )
+        )
+
+    fig.update_layout(
+        title=dict(
+            text="Summary Image",
+            x=0.5,
+            xanchor="center",
+            font=dict(size=18),
+        ),
+        updatemenus=[
+            {
+                "buttons": [
+                    {
+                        "label": "Average Projection",
+                        "method": "update",
+                        "args": [{"visible": [True, False] + [True] * mask_ids.size}],
+                    },
+                    {
+                        "label": "Max Projection",
+                        "method": "update",
+                        "args": [{"visible": [False, True] + [True] * mask_ids.size}],
+                    },
+                ],
+                "direction": "down",
+                "showactive": True,
+                "x": 0.5,
+                "xanchor": "center",
+                "y": 1.1,
+            }
+        ],
+        height=fig_height,
+        width=fig_width,
+        margin=dict(t=fig_height / 6, b=40),
     )
 
-    trace_fig.update_layout(get_tracelayout(cell_key))
+    return fig
 
-    return trace_fig
+
+def figure_data(miniscope_module, segmentation_key):
+    miniscope = dj.create_virtual_module("miniscope", miniscope_module)
+
+    average_image = np.squeeze(
+        (miniscope.MotionCorrection.Summary & segmentation_key).fetch1("average_image")
+    )
+    max_projection_image = np.squeeze(
+        (miniscope.MotionCorrection.Summary & segmentation_key).fetch1("max_proj_image")
+    )
+    mask_ids, mask_xpix, mask_ypix = (
+        miniscope.Segmentation.Mask & segmentation_key
+    ).fetch("mask", "mask_xpix", "mask_ypix")
+
+    return average_image, max_projection_image, mask_ids, mask_xpix, mask_ypix

--- a/element_miniscope/plotting/cell_plot.py
+++ b/element_miniscope/plotting/cell_plot.py
@@ -1,0 +1,208 @@
+from typing import Tuple
+
+import numpy as np
+import plotly.graph_objects as go
+from matplotlib import colors
+
+
+def mask_overlayed_image(
+    image, mask_xpix, mask_ypix, cell_mask_ids, low_q=0, high_q=0.99
+):
+    """Overlay transparent cell masks on average image."""
+
+    q_min, q_max = np.quantile(image, [low_q, high_q])
+    image = np.clip(image, q_min, q_max)
+    image = (image - q_min) / (q_max - q_min)
+
+    SATURATION = 0.7
+    image = image[:, :, None] * np.array([0, 0, 1])
+    maskid_image = np.full(image.shape[:2], -1)
+    for xpix, ypix, roi_id in zip(mask_xpix, mask_ypix, cell_mask_ids):
+        image[ypix, xpix, :2] = [np.random.rand(), SATURATION]
+        maskid_image[ypix, xpix] = roi_id
+    image = (colors.hsv_to_rgb(image) * 255).astype(int)
+    return image, maskid_image
+
+
+def get_tracelayout(key, width=600, height=600) -> dict:
+    """Returns a dictionary of layout settings for the trace figures."""
+    text = f"Trace for Cell {key['mask']}" if isinstance(key, dict) else "Trace"
+
+    return dict(
+        margin=dict(l=0, r=0, b=0, t=65, pad=0),
+        width=width,
+        height=height,
+        transition={"duration": 0},
+        title={
+            "text": text,
+            "xanchor": "center",
+            "yanchor": "top",
+            "y": 0.97,
+            "x": 0.5,
+        },
+        xaxis={
+            "title": "Time (sec)",
+            "visible": True,
+            "showticklabels": True,
+            "showgrid": True,
+        },
+        yaxis={
+            "title": "Fluorescence (a.u.)",
+            "visible": True,
+            "showticklabels": True,
+            "showgrid": True,
+            "anchor": "free",
+            "overlaying": "y",
+            "side": "left",
+            "position": 0,
+        },
+        yaxis2={
+            "title": "Calcium Event (a.u.)",
+            "visible": True,
+            "showticklabels": True,
+            "showgrid": True,
+            "anchor": "free",
+            "overlaying": "y",
+            "side": "right",
+            "position": 1,
+        },
+        shapes=[
+            go.layout.Shape(
+                type="rect",
+                xref="paper",
+                yref="paper",
+                x0=0,
+                y0=0,
+                x1=1.0,
+                y1=1.0,
+                line={"width": 1, "color": "black"},
+            )
+        ],
+        legend={
+            "traceorder": "normal",
+            "yanchor": "top",
+            "y": 0.99,
+            "xanchor": "right",
+            "x": 0.99,
+        },
+        plot_bgcolor="rgba(0,0,0,0.05)",
+        modebar_remove=[
+            "zoom",
+            "resetScale",
+            "pan",
+            "select",
+            "zoomIn",
+            "zoomOut",
+            "autoScale2d",
+        ],
+    )
+
+
+def figure_data(miniscope_module, segmentation_key) -> Tuple[np.array, np.array]:
+    """Prepare the images for a given segmentation_key.
+
+    Args:
+        miniscope_module (dj.Table): miniscope_module table.
+        segmentation_key (dict): A primary key from Segmentation table.
+
+    Returns:
+        background_with_cells (np.array): Average image with transparently overlayed
+            cells.
+        cells_maskid_image (np.array): Mask ID image.
+    """
+
+    image = (miniscope_module.MotionCorrection.Summary & segmentation_key).fetch1(
+        "average_image"
+    )
+
+    cell_mask_ids, mask_xpix, mask_ypix = (
+        miniscope_module.Segmentation.Mask * miniscope_module.MaskClassification.MaskType
+        & segmentation_key
+    ).fetch("mask", "mask_xpix", "mask_ypix")
+
+    background_with_cells, cells_maskid_image = mask_overlayed_image(
+        image, mask_xpix, mask_ypix, cell_mask_ids, low_q=0, high_q=0.99
+    )
+
+    return background_with_cells, cells_maskid_image
+
+
+def plot_cell_overlayed_image(miniscope_module, segmentation_key) -> go.Figure:
+    """_summary_
+
+    Args:
+        miniscope_module (dj.Table): miniscope_module table.
+        segmentation_key (dict): A primary key from Segmentation table.
+
+    Returns:
+        image_fig (plotly.Fig): Plotly figure object of the average image with
+            transparently overlayed cells.
+    """
+
+    background_with_cells, cells_maskid_image = figure_data(miniscope_module, segmentation_key)
+
+    image_fig = go.Figure(
+        go.Image(
+            z=background_with_cells,
+            hovertemplate="x: %{x} <br>y: %{y} <br>mask_id: %{customdata}",
+            customdata=cells_maskid_image,
+        )
+    )
+    image_fig.update_layout(
+        title="Average Image with Cells",
+        xaxis={
+            "title": "X (px)",
+            "visible": True,
+            "showticklabels": True,
+            "showgrid": False,
+        },
+        yaxis={
+            "title": "Y (px)",
+            "visible": True,
+            "showticklabels": True,
+            "showgrid": False,
+        },
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+    )
+
+    return image_fig
+
+
+def plot_cell_traces(miniscope_module, cell_key) -> go.Figure:
+    """Prepare plotly trace figure.
+
+    Args:
+        miniscope_module (dj.Table): miniscope_module table.
+        cell_key (dict): A primary key from miniscope_module.Activity.Trace table.
+
+    Returns:
+        trace_fig: Plotly figure object of the traces.
+    """
+    activity_trace = (
+        miniscope_module.Activity.Trace & "extraction_method LIKE '%deconvolution'" & cell_key
+    ).fetch1("activity_trace")
+    fluorescence, fps = (miniscope_module.RecordingInfo * miniscope_module.Fluorescence.Trace & cell_key).fetch1(
+        "fluorescence", "fps"
+    )
+
+    trace_fig = go.Figure(
+        [
+            go.Scatter(
+                x=np.arange(len(fluorescence)) / fps,
+                y=fluorescence,
+                name="Fluorescence",
+                yaxis="y1",
+            ),
+            go.Scatter(
+                x=np.arange(len(activity_trace)) / fps,
+                y=activity_trace,
+                name="Calcium Event",
+                yaxis="y2",
+            ),
+        ]
+    )
+
+    trace_fig.update_layout(get_tracelayout(cell_key))
+
+    return trace_fig

--- a/element_miniscope/plotting/cell_plot.py
+++ b/element_miniscope/plotting/cell_plot.py
@@ -1,54 +1,46 @@
 import datajoint as dj
+import plotly.express as px
 import plotly.graph_objects as go
 import numpy as np
+import colorsys
 
 
 def plot_cell_overlayed_image(
-    miniscope_module, segmentation_key, fig_height=600, fig_width=600
+    miniscope_module, segmentation_key, fig_height=600, fig_width=600, mask_saturation=0.7, mask_color_value=1
 ) -> go.Figure:
 
     average_image, max_projection_image, mask_ids, mask_xpix, mask_ypix = figure_data(
         miniscope_module, segmentation_key
     )
 
-    fig = go.Figure()
+    roi_hsv_colors = [np.random.rand() for _ in range(mask_ids.size)]
 
-    # Add heatmaps for the average and max projection images
-    fig.add_trace(
-        go.Heatmap(
-            z=average_image,
-            colorscale=[[0, "black"], [1, "white"]],
-            showscale=False,
-            visible=True,  # Initially visible
-        )
+    # Convert HSV colors to RGB for Plotly
+    roi_rgb_colors = []
+    for hue in roi_hsv_colors:
+        rgb = colorsys.hsv_to_rgb(hue, mask_saturation, mask_color_value)
+        rgb_scaled = tuple(int(c * 255) for c in rgb) 
+        roi_rgb_colors.append(f"rgb{rgb_scaled}")  # Convert to Plotly-compatible format
+
+    fig = px.imshow(
+    average_image,  # Initial image (can toggle later)
+    color_continuous_scale="gray",
+    labels={"color": "Intensity"},
     )
-
-    fig.add_trace(
-        go.Heatmap(
-            z=max_projection_image,
-            colorscale=[[0, "black"], [1, "white"]],
-            showscale=False,
-            visible=False,  # Initially hidden
-        )
-    )
-
-    roi_colors = [
-        f"rgb({np.random.randint(0, 256)}, {np.random.randint(0, 256)}, {np.random.randint(0, 256)})"
-        for _ in range(mask_ids.size)
-    ]
-
-    # Add scatter traces for ROI contours
-    for xpix, ypix, color, roi_id in zip(mask_xpix, mask_ypix, roi_colors, mask_ids):
+    fig.update_coloraxes(showscale=False)
+    # Add scatter traces for ROI contours (keeping HSV logic internally)
+    for xpix, ypix, color, roi_id in zip(mask_xpix, mask_ypix, roi_rgb_colors, mask_ids):
         fig.add_trace(
             go.Scatter(
                 x=xpix,
                 y=ypix,
                 mode="lines",
-                line=dict(color=color, width=2),
+                line=dict(color=color, width=2),  # Use HSV-based color (converted to RGB)
+                name=f"ROI {roi_id}",
                 hoverinfo="text",
-                text=[f"ROI {roi_id}"] * len(xpix),  # Display ROI ID on hover
-                showlegend=False,  # Hide legend for ROI contours
-                opacity=0.7,  # Adjust line transparency
+                text=[f"ROI {roi_id}"] * len(xpix),
+                showlegend=False,
+                opacity=0.5,
             )
         )
 
@@ -65,12 +57,12 @@ def plot_cell_overlayed_image(
                     {
                         "label": "Average Image",
                         "method": "update",
-                        "args": [{"visible": [True, False] + [True] * mask_ids.size}],
+                        "args": [{"z": [average_image]}],
                     },
                     {
                         "label": "Max Projection Image",
                         "method": "update",
-                        "args": [{"visible": [False, True] + [True] * mask_ids.size}],
+                        "args": [{"z": [max_projection_image]}],
                     },
                 ],
                 "direction": "down",

--- a/element_miniscope/plotting/cell_plot.py
+++ b/element_miniscope/plotting/cell_plot.py
@@ -63,12 +63,12 @@ def plot_cell_overlayed_image(
             {
                 "buttons": [
                     {
-                        "label": "Average Projection",
+                        "label": "Average Image",
                         "method": "update",
                         "args": [{"visible": [True, False] + [True] * mask_ids.size}],
                     },
                     {
-                        "label": "Max Projection",
+                        "label": "Max Projection Image",
                         "method": "update",
                         "args": [{"visible": [False, True] + [True] * mask_ids.size}],
                     },

--- a/element_miniscope/plotting/cell_plot.py
+++ b/element_miniscope/plotting/cell_plot.py
@@ -89,16 +89,15 @@ def plot_cell_overlayed_image(
 
 
 def figure_data(miniscope_module, segmentation_key):
-    miniscope = dj.create_virtual_module("miniscope", miniscope_module)
 
     average_image = np.squeeze(
-        (miniscope.MotionCorrection.Summary & segmentation_key).fetch1("average_image")
+        (miniscope_module.MotionCorrection.Summary & segmentation_key).fetch1("average_image")
     )
     max_projection_image = np.squeeze(
-        (miniscope.MotionCorrection.Summary & segmentation_key).fetch1("max_proj_image")
+        (miniscope_module.MotionCorrection.Summary & segmentation_key).fetch1("max_proj_image")
     )
     mask_ids, mask_xpix, mask_ypix = (
-        miniscope.Segmentation.Mask & segmentation_key
+        miniscope_module.Segmentation.Mask & segmentation_key
     ).fetch("mask", "mask_xpix", "mask_ypix")
 
     return average_image, max_projection_image, mask_ids, mask_xpix, mask_ypix


### PR DESCRIPTION
The `cell_plot.py` file below adds a plotly-based visualizations for summary images (average image and max proj image with masks). The user can select from the drop down if they'd like to view the average image or max projection image. 

![image](https://github.com/user-attachments/assets/72e0a8c4-0d08-4c44-a309-2e63477bc0f9)
